### PR TITLE
feat: correct the plugin interface

### DIFF
--- a/lib/legacy/common.ts
+++ b/lib/legacy/common.ts
@@ -13,6 +13,19 @@ export interface DepTree extends DepTreeDep {
     name: string;
     version: string;
   };
+  labels?: {
+    [key: string]: string;
+
+    // Known keys:
+    // pruned: identical subtree already presents in the parent node.
+    //         See --prune-repeated-subdependencies flag.
+  };
+
+  // TODO: clarify which of these extra files are actually needed
+  targetFile?: string;
+  policy?: string;
+  docker?: any;
+  files?: any;
 }
 
 export interface ScannedProject {
@@ -25,3 +38,7 @@ export interface ScannedProject {
 
   meta?: any; // TODO(BST-542): decide on the format
 }
+
+export type SupportedPackageManagers = 'rubygems' | 'npm' | 'yarn' |
+'maven' | 'pip' | 'sbt' | 'gradle' | 'golangdep' | 'govendor' | 'gomodules' |
+'nuget' | 'paket' | 'composer';


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Corrects the "inspect" definition (the "async" bit was doing the wrong thing :( )
Tidies up the names of InspectOptions / Results, adds combined convenience types.

Also: additional fields on DepTree.
Also: SupportedPackageManagers.

