### PR TITLE
feat: a version of Plugin interface that only returns one subproject

### DIFF
--- a/lib/legacy/plugin.ts
+++ b/lib/legacy/plugin.ts
@@ -6,6 +6,21 @@ export interface Plugin {
   inspect(root: string, targetFile?: string, options?: InspectOptions): Promise<InspectResult>;
 }
 
+export interface SingleSubprojectPlugin {
+  inspect(root: string, targetFile?: string, options?: SingleSubprojectInspectOptions): Promise<SinglePackageResult>;
+  pluginName(): string;
+}
+
+export function adaptSingleProjectPlugin(plugin: SingleSubprojectPlugin): Plugin {
+  return { inspect: (root: string, targetFile?: string, options?: InspectOptions) => {
+    if (options && isMultiSubProject(options)) {
+      throw new Error(`Plugin ${plugin.pluginName()} does not support scanning multiple sub-projects`);
+    } else {
+      return plugin.inspect(root, targetFile, options);
+    }
+  }} as Plugin;
+}
+
 export interface BaseInspectOptions {
   dev?: boolean;
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Many plugins only ever return one project. It's easier for them to conform to this interface.

