### PR TITLE
fix: CLI interface to be fully compliant with current CLI logic

### DIFF
--- a/lib/legacy/common.ts
+++ b/lib/legacy/common.ts
@@ -39,6 +39,13 @@ export interface ScannedProject {
   meta?: any; // TODO(BST-542): decide on the format
 }
 
-export type SupportedPackageManagers = 'rubygems' | 'npm' | 'yarn' |
-'maven' | 'pip' | 'sbt' | 'gradle' | 'golangdep' | 'govendor' | 'gomodules' |
-'nuget' | 'paket' | 'composer';
+export type SupportedPackageManagers =
+  'rubygems' | // Ruby
+  'npm' | 'yarn' | // Node.js
+  'maven' | 'sbt' | 'gradle' | // JVM
+  'golangdep' | 'govendor' | 'gomodules' | // Go
+  'pip' | // Python
+  'nuget' | 'paket' | // .Net
+  'composer' | // PHP
+  'rpm' | 'apk' | 'deb' | 'dockerfile' // Docker (Linux)
+  ;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Final batch of updates discovered as necessary to painlessly import this in CLI:
- docker package managers (used in CLI tests)
- single subproject plugin now is as simple as possible (to comply with tests)
- meta.runtime is optional

See also https://github.com/snyk/snyk/pull/616