### PR TITLE
feat: revert to overload signatures instead of conditional types

### DIFF
--- a/lib/legacy/plugin.ts
+++ b/lib/legacy/plugin.ts
@@ -13,8 +13,13 @@ export interface SingleSubprojectPlugin {
 
 // New-style plugins that can return multiple results (e.g. Gradle).
 export interface Plugin extends SingleSubprojectPlugin {
-  inspect<T extends InspectOptions>(root: string, targetFile?: string, options?: T):
-    Promise<T extends MultiSubprojectInspectOptions ? MultiProjectResult : SinglePackageResult>;
+  // Actual function should implement this
+  inspect(root: string, targetFile?: string, options?: InspectOptions): Promise<InspectResult>;
+
+  // But we also guarantee that for Single-/Multiple- options we produce Single-/Multiple- result.
+  // The actual implementations should include these two declaration lines to confirm the guarantee.
+  inspect(root: string, targetFile?: string, options?: SingleSubprojectInspectOptions): Promise<SinglePackageResult>;
+  inspect(root: string, targetFile: string | undefined, options: MultiSubprojectInspectOptions): Promise<MultiProjectResult>;
 }
 
 export function adaptSingleProjectPlugin(plugin: SingleSubprojectPlugin): Plugin {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Reverts the previous refactoring (https://github.com/snyk/snyk-cli-interface/pull/9).

Unfortunately, TypeScript conditional types are not smart enough to handle `options` being optional.
Having method overloads is still the safest method to describe the plugin behavior.
