### PR TITLE
fix: Fix exports, add depTree to exports too

### DIFF
--- a/lib/legacy/index.ts
+++ b/lib/legacy/index.ts
@@ -1,4 +1,5 @@
-import * as pluginInterface from './plugin';
-import * as monitorInterface from './monitor';
+import * as plugin from './plugin';
+import * as monitor from './monitor';
+import * as common from './monitor';
 
-export {pluginInterface, monitorInterface};
+export {plugin, monitor, common};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
       "pretty": true,
       "target": "es2015",
       "lib": [
-        "es2015",
+        "es2015"
       ],
       "module": "commonjs",
       "allowJs": false,
@@ -12,7 +12,7 @@
       "strict": true,
       "declaration": true,
       "importHelpers": true,
-      "noImplicitAny": false // Needed to compile tap and ansi-escapes
+      "noImplicitAny": false
   },
   "include": [
       "./lib/**/*"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- expose top level types without the need to reference `dist`
- export `depTree` type