### PR TITLE
[EXPERIMENTAL] feat: publish without dist (for nicer imports from subpackages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,8 @@ typings/
 # next.js build output
 .next
 
-dist
 package-lock.json
+*.d.ts
+*.js
+*.js.map
+legacy/

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "type": "git",
     "url": "https://github.com/snyk/snyk-cli-interface"
   },
-  "main": "dist/index.js",
+  "main": "index.js",
   "files": [
-    "dist"
+    "**/*.d.ts",
+    "**/*.js",
+    "**/*.js.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-      "outDir": "./dist",
+      "outDir": ".",
       "pretty": true,
       "target": "es2015",
       "lib": [
@@ -16,5 +16,6 @@
   },
   "include": [
       "./lib/**/*"
-  ]
+  ],
+  "exclude": [],
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Currently, the imports of types from this package look like this:
```
import {
  SingleSubprojectInspectOptions, MultiSubprojectInspectOptions, SinglePackageResult, MultiProjectResult,
  PluginMetadata, InspectOptions, InspectResult, isMultiSubProject,
} from '@snyk/cli-interface/dist/legacy/plugin';
import { DepTree, ScannedProject } from '@snyk/cli-interface/dist/legacy/common';
```

This PR allows to get rid of the `dist` part:
```
import {
  SingleSubprojectInspectOptions, MultiSubprojectInspectOptions, SinglePackageResult, MultiProjectResult,
  PluginMetadata, InspectOptions, InspectResult, isMultiSubProject,
} from '@snyk/cli-interface/legacy/plugin';
import { DepTree, ScannedProject } from '@snyk/cli-interface/legacy/common';
```

... at the cost of this repository being treated as "special" and not following the regular Snyk conventions re compiling to `dist`.

Alternative, similar approach: do not compile with `tsc` at all, just publish .ts files as they are in the npm package, since this module is supposed to be consumed by Typescript code only anyway.