### PR TITLE
[EXPERIMENTAL] feat: expose all submodules at top-level, for easier importing

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,7 @@
-import * as legacy from './legacy';
-export { legacy };
+import {plugin, monitor, common} from './legacy';
+
+export {
+    plugin as legacyPlugin,
+    monitor as legacyMonitor,
+    common as legacyCommon
+}

--- a/lib/legacy/index.ts
+++ b/lib/legacy/index.ts
@@ -1,4 +1,5 @@
-import * as pluginInterface from './plugin';
-import * as monitorInterface from './monitor';
+import * as plugin from './plugin';
+import * as monitor from './monitor';
+import * as common from './common';
 
-export {pluginInterface, monitorInterface};
+export {plugin, monitor, common};


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Currently, the imports of types from this package look like this:
```
import {
  SingleSubprojectInspectOptions, MultiSubprojectInspectOptions, SinglePackageResult, MultiProjectResult,
  PluginMetadata, InspectOptions, InspectResult, isMultiSubProject,
} from '@snyk/cli-interface/dist/legacy/plugin';
import { DepTree, ScannedProject } from '@snyk/cli-interface/dist/legacy/common';
```

This PR allows to get rid of the `dist` part:
```
import {
  legacyPlugin, legacyCommon
} from '@snyk/cli-interface';
type DepTree = legacyCommon.DepTree;
type ScannedProject = legacyCommon.ScannedProject;
type SingleSubprojectInspectOptions = legacyPlugin.SingleSubprojectInspectOptions;
type InspectOptions = legacyPlugin.InspectOptions;
type SinglePackageResult = legacyPlugin.SinglePackageResult;
type PluginMetadata = legacyPlugin.PluginMetadata;
type MultiSubprojectInspectOptions = legacyPlugin.MultiSubprojectInspectOptions;
type InspectResult = legacyPlugin.InspectResult;
type MultiProjectResult = legacyPlugin.MultiProjectResult;
const isMultiSubProject = legacyPlugin.isMultiSubProject;
```

... at the cost of not being able to import unqualified names directly.