### PR TITLE
fix: publish the library as compiled Javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,10 @@ typings/
 # next.js build output
 .next
 
+# built files
 dist
+*.d.ts
+*.js
+*.js.map
+
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -5,5 +5,20 @@ Interface definitions for interactions between Snyk CLI and associated component
 * monitor states sent to snyk.io website
 
 This library should be only imported from Typescript.
-As such, the `npm` package is containing the `.ts` files
-(not the compiled `dist` directory).
+
+The types can be imported in one of the following ways:
+
+* whole sub-module import from the top level
+
+    import { legacyPlugin as api } from '@snyk/cli-interface';
+    // use api.InspectOptions
+
+* "deep import" (discouraged but possible)
+
+    import { InspectOptions } from '@snyk/cli-interface/legacy/plugin';
+
+The `npm` package does not follow the usual Snyk convention and
+exports the build files in the root directory, not in dist, to enable "deep imports".
+
+We still have to publish the package using the compiled files, because many tools in Node.js
+ecosystem assume that published libraries should be always in Javascript.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "main": "index.ts",
   "files": [
-    "**/*.ts"
+    "**/*.d.ts",
+    "**/*.js",
+    "**/*.js.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-      "outDir": "./dist",
       "pretty": true,
       "target": "es2015",
       "lib": [


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Turns out, publishing a package of `.ts` files is problematic. `ts-node` (used by TAP) won't compile external packages by default. So, switching to publishing a compiled version.