### PR TITLE
fix: ensure type compatibility to @snyk/dep-graph

### DIFF
--- a/legacy/common.ts
+++ b/legacy/common.ts
@@ -5,7 +5,7 @@ export interface DepTreeDep {
     [depName: string]: DepTreeDep,
   };
   labels?: {
-    [key: string]: string;
+    [key: string]: string | undefined;
 
     // Known keys:
     // pruned: identical subtree already presents in the parent node.

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "build": "tsc",
     "lint": "tslint --project tsconfig.json --format stylish",
     "prepare": "npm run build",
-    "test": "npm run build && npm run lint"
+    "test": "npm run build && npm run lint && npm run test:compat",
+    "test:compat": "tsc --strict --noEmit ./test/*.ts"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@snyk/dep-graph": "^1.12.0",
     "tslint": "^5.14.0",
     "typescript": "^3.3.4000"
   },

--- a/test/dep-tree-compatibility.ts
+++ b/test/dep-tree-compatibility.ts
@@ -1,0 +1,8 @@
+import * as depGraph from '@snyk/dep-graph';
+import { legacyCommon as common } from '../index';
+
+/// Note: if the type signature of the `DepTree` in the `@snyk/dep-graph`
+/// package is incompatible with the `DepTree` defined in this package,
+/// this file fails to compile.
+const depTree: depGraph.legacy.DepTree = {}
+export const legacyCommonDepTreeTyped: common.DepTree = depTree;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "importHelpers": true
   },
   "include": [
-      "./**/*.ts"
+      "index.ts",
+      "legacy/**/*.ts"
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes #18 and ensures that the types are compatible going forward.

#### How should this be manually tested?

Revert the change in `legacy/common.ts` and `npm run test:compat`.

I did. The test failed successfully:
```
> @snyk/cli-interface@ test:compat /Users/marius/Development/Snyk/snyk-cli-interface
> tsc --strict --noEmit ./test/*.ts

test/dep-tree-compatibility.ts:8:14 - error TS2322: Type 'import("/Users/marius/Development/Snyk/snyk-cli-interface/node_modules/@snyk/dep-graph/dist/legacy/index").DepTree' is not assignable to type 'import("/Users/marius/Development/Snyk/snyk-cli-interface/legacy/common").DepTree'.
  Types of property 'dependencies' are incompatible.
    Type '{ [depName: string]: DepTreeDep; } | undefined' is not assignable to type '{ [depName: string]: import("/Users/marius/Development/Snyk/snyk-cli-interface/legacy/common").DepTreeDep; } | undefined'.
      Type '{ [depName: string]: DepTreeDep; }' is not assignable to type '{ [depName: string]: import("/Users/marius/Development/Snyk/snyk-cli-interface/legacy/common").DepTreeDep; }'.
        Index signatures are incompatible.
          Type 'DepTreeDep' is not assignable to type 'import("/Users/marius/Development/Snyk/snyk-cli-interface/legacy/common").DepTreeDep'.
            Types of property 'labels' are incompatible.
              Type '{ [key: string]: string | undefined; scope?: "dev" | "prod" | undefined; pruned?: "cyclic" | "true" | undefined; } | undefined' is not assignable to type '{ [key: string]: string; } | undefined'.
                Type '{ [key: string]: string | undefined; scope?: "dev" | "prod" | undefined; pruned?: "cyclic" | "true" | undefined; }' is not assignable to type '{ [key: string]: string; }'.
                  Index signatures are incompatible.
                    Type 'string | undefined' is not assignable to type 'string'.
                      Type 'undefined' is not assignable to type 'string'.

8 export const legacyCommonDepTreeTyped: common.DepTree = depTree;
               ~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

#### Any background context you want to provide?

Configuring TypeScript to compile the right things from CLI was confusing.