### PR TITLE
feat: skipUnresolved option for inspect

### DIFF
--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -44,6 +44,8 @@ export function adaptSingleProjectPlugin(plugin: SingleSubprojectPlugin): Plugin
 export interface BaseInspectOptions {
   // Include dev dependencies
   dev?: boolean;
+  // Skip any deps we could not resolve, and continue
+  skipUnresolved?: boolean;
 
   // Additional command line arguments to the underlying tool,
   // supplied after "--" to the Snyk CLI.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
sometimes we won't be able to either:
- find the package locally when we know it should be there
- resolve a package version that stisfying language resolution rules and semver range

This option is common to any plugin that can log the issue and keep going via the `--skip-unresolved` flag

#### Where should the reviewer start?

https://github.com/snyk/snyk/pull/864