### PR TITLE
chore: Add java and maven version

### DIFF
--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -101,7 +101,7 @@ export interface PluginMetadata {
 }
 
 export interface VersionBuildInfo {
-  gradleVersion: string;
+  gradleVersion?: string;
   metaBuildVersion: { [index: string]: string };
 }
 


### PR DESCRIPTION
For better visibility into java version, report  java and maven versions in metadata. For more clarity, gradle specific `VersionBuildInfo` was renamed.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Just adds new properties to interface.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
