### PR TITLE
fix: added packageFormatVersion to PluginMetadata Interface.

### DIFF
--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -98,6 +98,7 @@ export interface PluginMetadata {
   // Docker-related fields
   dockerImageId?: any;
   imageLayers?: any;
+  packageFormatVersion?: string;
 }
 
 export interface VersionBuildInfo {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adding a missing field packageFormatVersion to PluginMetadata to use it on CLI.

