### PR TITLE
fix: ignore custom type any tslib error

### DIFF
--- a/legacy/common.ts
+++ b/legacy/common.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import * as graphlib from '@snyk/graphlib';
 
 export interface DepTreeDep {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
```
../snyk-cli-interface/legacy/common.ts:1:27 - error TS7016: Could not find a declaration file for module '@snyk/graphlib'. '/Users/lili/www/snyk/snyk-cli-interface/node_modules/@snyk/graphlib/index.js' implicitly has an 'any' type.
  Try `npm install @types/snyk__graphlib` if it exists or add a new declaration (.d.ts) file containing `declare module '@snyk/graphlib';
````
Custom type workaround for the vuln fix is making other libraries consuming this not happy, this ignores the error. But we need a better fix for this.
