### PR TITLE
feat: support dep-graph, deptree and depgraph optional types

### DIFF
--- a/legacy/common.ts
+++ b/legacy/common.ts
@@ -1,6 +1,7 @@
 import * as graphlib from '@snyk/graphlib';
 import { DepGraph } from '@snyk/dep-graph';
 
+export { DepGraph };
 export interface DepTreeDep {
   name?: string; // shouldn't, but might be missing
   version?: string; // shouldn't, but might be missing

--- a/legacy/monitor.ts
+++ b/legacy/monitor.ts
@@ -1,9 +1,10 @@
-import { DepTree } from './common';
+import { DepTree, DepGraph } from './common';
 
 export interface MonitorBody {
   meta: MonitorMeta;
   policy: string;
-  package: DepTree;
+  package?: DepTree;
+  dependencyGraph?: DepGraph;
   targetFile: string;
 }
 

--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -1,4 +1,4 @@
-import { CallGraph, DepTree, ScannedProject, SupportedPackageManagers } from './common';
+import { CallGraph, DepGraph, DepTree, ScannedProject, SupportedPackageManagers } from './common';
 
 // Interface definitions for DepTree-returning dependency analysis plugins for Snyk CLI.
 
@@ -64,7 +64,6 @@ export interface SingleSubprojectInspectOptions extends BaseInspectOptions {
 }
 
 export interface MultiSubprojectInspectOptions extends BaseInspectOptions {
-
   // Return multiple "subprojects" as a MultiProjectResult.
   // Sub-projects correspond to sub-projects in Gradle or projects in a Yarn workspace.
   // Eventually, this flag will be an implicit default and all the plugins
@@ -113,6 +112,7 @@ export interface VersionBuildInfo {
 export interface SinglePackageResult {
   plugin: PluginMetadata;
   package: DepTree;
+  dependencyGraph?: DepGraph;
   callGraph?: CallGraph;
   meta?: {
     gradleProjectName?: string,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

add missing depGraph types, makes depGraph and depTree 
optional to allow the coexistence of them