### PR TITLE
fix: expose call graph creation errors

### DIFF
--- a/legacy/common.ts
+++ b/legacy/common.ts
@@ -42,7 +42,7 @@ export interface ScannedProject {
   targetFile?: string;
 
   meta?: any; // TODO(BST-542): decide on the format
-  callGraph?: CallGraph;
+  callGraph?: CallGraphResult;
 }
 
 export type SupportedPackageManagers =
@@ -56,4 +56,11 @@ export type SupportedPackageManagers =
   'rpm' | 'apk' | 'deb' | 'dockerfile' // Docker (Linux)
   ;
 
+export interface CallGraphError {
+  message: string;
+  innerError: Error;
+}
+
 export type CallGraph = graphlib.Graph;
+
+export type CallGraphResult = CallGraph | CallGraphError;

--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -1,4 +1,4 @@
-import { CallGraph, DepGraph, DepTree, ScannedProject, SupportedPackageManagers } from './common';
+import { CallGraph, CallGraphResult, DepGraph, DepTree, ScannedProject, SupportedPackageManagers } from './common';
 
 // Interface definitions for DepTree-returning dependency analysis plugins for Snyk CLI.
 
@@ -113,7 +113,7 @@ export interface SinglePackageResult {
   plugin: PluginMetadata;
   package: DepTree;
   dependencyGraph?: DepGraph;
-  callGraph?: CallGraph;
+  callGraph?: CallGraphResult;
   meta?: {
     gradleProjectName?: string,
     versionBuildInfo?: VersionBuildInfo,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Expose the error that occurred while creating the call graph, if any. This allows the CLI tool to give better error messages, and to send call graph errors to the analytics system.