### PR TITLE
feat: optional meta targetFile

### DIFF
--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -96,6 +96,9 @@ export interface PluginMetadata {
   meta?: {
     allSubProjectNames?: string[],
     versionBuildInfo?: VersionBuildInfo,
+    // returning targetFile in plugin can cause issue with project unique
+    // constraints, returning here when used outside of that.
+    targetFile?: string;
   };
 
   // Docker-related fields


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
returning targetFile in plugin can cause issue with project unique constraints, returning here when used outside of that.

Used in: https://github.com/snyk/snyk-gradle-plugin/pull/142/files
