### PR TITLE
feat: upgrade dep-graph (removing weird transitive)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "^3.3.4000"
   },
   "dependencies": {
-    "@snyk/dep-graph": "1.19.4",
+    "@snyk/dep-graph": "1.20.0",
     "@types/graphlib": "^2.1.7",
     "tslib": "^1.9.3"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "tslint": "^5.14.0",
-    "typescript": "^3.3.4000"
+    "typescript": "~3.8.3"
   },
   "dependencies": {
     "@snyk/dep-graph": "1.20.0",


### PR DESCRIPTION
Pick up a minor release of `@snyk/dep-graph`, which we have pinned. This version bump brings the removal of `source-map-support`, which is inappropriate behaviour for a library.

Also ~pin typescript, so the build doesn't randomly break on upgrades. (They don't do semver.)