### PR TITLE
fix: make DepTree optional for SinglePackageResult

### DIFF
--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -114,7 +114,7 @@ export interface VersionBuildInfo {
 
 export interface SinglePackageResult {
   plugin: PluginMetadata;
-  package: DepTree;
+  package?: DepTree;
   dependencyGraph?: DepGraph;
   callGraph?: CallGraphResult;
   meta?: {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Make "package" property optional for SinglePackageResult
