### PR TITLE
fix: set the peerDependencies to be less strict about the depGraph ve…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "@types/graphlib": "^2"
   },
   "peerDependencies": {
-    "@snyk/dep-graph": "1.19.2",
-    "@snyk/graphlib": "2.1.9-patch",
-    "tslib": "^1.9.3"
+    "@snyk/dep-graph": "^1"
   }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
set the peerDependencies to be less strict about the depGraph version
