### PR TITLE
fix: [SUP-2164] adding projectName to the SinglePackageResult

### DIFF
--- a/legacy/plugin.ts
+++ b/legacy/plugin.ts
@@ -122,6 +122,7 @@ export interface SinglePackageResult {
   dependencyGraph?: DepGraph;
   callGraph?: CallGraphResult;
   meta?: {
+    projectName?: string,
     gradleProjectName?: string,
     versionBuildInfo?: VersionBuildInfo,
   };


### PR DESCRIPTION
There are some discrepancies between the metadata returned when doing a `snyk monitor` and a `snyk test` with the gradle plugin.

As you can see here, 
* in monitor, the resulting metadata becomes: https://github.com/snyk/snyk-gradle-plugin/blob/132b8e2740b823763493e07e2062c11b4e7cf8ed/lib/index.ts#L314-L319
* in test, the resulting metadata becomes: https://github.com/snyk/snyk-gradle-plugin/blob/132b8e2740b823763493e07e2062c11b4e7cf8ed/lib/index.ts#L158-L160

This causes issues for customers when monitor and test are not interpreted as the same project by the Snyk backend.