### PR TITLE
chore: add uv as supported package manager

### DIFF
--- a/legacy/common.ts
+++ b/legacy/common.ts
@@ -50,7 +50,7 @@ export type SupportedPackageManagers =
   'npm' | 'yarn' | // Node.js
   'maven' | 'sbt' | 'gradle' | // JVM
   'golangdep' | 'govendor' | 'gomodules' | // Go
-  'pip' | // Python
+  'pip' | 'uv' | // Python
   'nuget' | 'paket' | // .Net
   'composer' | // PHP
   'rpm' | 'apk' | 'deb' | 'dockerfile' // Docker (Linux)


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Add uv as a supported package manager so that the uv plugin in the CLI can return a MultiProject result with 'uv' as the package manager.

Otherwise have to do a cast like this
```
  const pluginPackageManager =
    'uv' as unknown as MultiProjectResult['plugin']['packageManager'];
```

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/UNIFY-1215

#### Screenshots


#### Additional questions
